### PR TITLE
Clip gradients during iteration-based training

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -76,10 +76,13 @@ def train_epoch(model, loader, optimizer, scaler, epoch, loss_func, args):
                 loss = loss_func(logits, target)
         if args.amp:
             scaler.scale(loss).backward()
+            scaler.unscale_(optimizer)
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
             scaler.step(optimizer)
             scaler.update()
         else:
             loss.backward()
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
             optimizer.step()
         if args.distributed:
             loss_list = distributed_all_gather([loss], out_numpy=True, is_valid=idx < loader.sampler.valid_length)


### PR DESCRIPTION
## Summary
- clip gradients in `train_epoch_by_iter` before optimizer step for AMP and non-AMP modes

## Testing
- `python -m py_compile trainer.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'einops'; `pip install einops` failed due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b142500f988329bdc7392eed861992