### PR TITLE
Normalize FFT weights and clip gradients

### DIFF
--- a/models/em_net_model.py
+++ b/models/em_net_model.py
@@ -139,6 +139,10 @@ class FFParser_n(nn.Module):
 
         x = x.reshape(B, C, H, W, D)
 
+        with torch.no_grad():
+            max_mag = self.complex_weight.abs().max()
+            self.complex_weight.div_(max_mag.clamp(min=1.0))
+
         return x
 
 class Spectral_Layer(nn.Module):

--- a/trainer.py
+++ b/trainer.py
@@ -140,10 +140,13 @@ def train_epoch_by_iter(model, loader, optimizer, scaler, epoch, loss_func, args
                 loss = loss_func(logits, target)
         if args.amp:
             scaler.scale(loss).backward()
+            scaler.unscale_(optimizer)
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
             scaler.step(optimizer)
             scaler.update()
         else:
             loss.backward()
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
             optimizer.step()
         if args.distributed:
             loss_list = distributed_all_gather([loss], out_numpy=True, is_valid=idx < loader.sampler.valid_length)


### PR DESCRIPTION
## Summary
- stabilize FFT parser by normalizing complex weights after each forward pass
- clamp gradients in iteration-based training loop

## Testing
- `python -m py_compile models/em_net_model.py trainer.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'einops')*

------
https://chatgpt.com/codex/tasks/task_e_68b15b02ab008329b762757dc8d7b51a