### PR TITLE
Normalize FFT weights using clone

### DIFF
--- a/models/em_net_model.py
+++ b/models/em_net_model.py
@@ -133,7 +133,9 @@ class FFParser_n(nn.Module):
         # x = x.view(B, a, b, C)
         x = x.to(torch.float32)
         x = torch.fft.rfftn(x, dim=(2, 3, 4), norm="ortho")
-        weight = torch.view_as_complex(self.complex_weight)
+        weight = torch.view_as_complex(self.complex_weight.clone())
+        max_mag = weight.abs().amax()
+        weight = weight / max_mag.clamp_min(1.0)
         x = x * weight
         x = torch.fft.irfftn(x, s=(H, W, D), dim=(2, 3, 4), norm="ortho")
 

--- a/models/em_net_model.py
+++ b/models/em_net_model.py
@@ -132,10 +132,10 @@ class FFParser_n(nn.Module):
 
         # x = x.view(B, a, b, C)
         x = x.to(torch.float32)
-        x = torch.fft.rfftn(x, dim=(2, 3, 4), norm='ortho')
+        x = torch.fft.rfftn(x, dim=(2, 3, 4), norm="ortho")
         weight = torch.view_as_complex(self.complex_weight)
         x = x * weight
-        x = torch.fft.irfftn(x, s=(H, W, D), dim=(2, 3, 4), norm='ortho')
+        x = torch.fft.irfftn(x, s=(H, W, D), dim=(2, 3, 4), norm="ortho")
 
         x = x.reshape(B, C, H, W, D)
 

--- a/trainer.py
+++ b/trainer.py
@@ -85,13 +85,6 @@ def train_epoch(model, loader, optimizer, scaler, epoch, loss_func, args):
             torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
             optimizer.step()
 
-        with torch.no_grad():
-            mod = model.module if args.distributed else model
-            for m in mod.modules():
-                if hasattr(m, "complex_weight"):
-                    w = torch.view_as_complex(m.complex_weight)
-                    w = w / w.abs().amax().clamp_min(1.0)
-                    m.complex_weight.copy_(torch.view_as_real(w))
         if args.distributed:
             loss_list = distributed_all_gather([loss], out_numpy=True, is_valid=idx < loader.sampler.valid_length)
             run_loss.update(
@@ -157,13 +150,6 @@ def train_epoch_by_iter(model, loader, optimizer, scaler, epoch, loss_func, args
             torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
             optimizer.step()
 
-        with torch.no_grad():
-            mod = model.module if args.distributed else model
-            for m in mod.modules():
-                if hasattr(m, "complex_weight"):
-                    w = torch.view_as_complex(m.complex_weight)
-                    w = w / w.abs().amax().clamp_min(1.0)
-                    m.complex_weight.copy_(torch.view_as_real(w))
 
         if args.distributed:
             loss_list = distributed_all_gather([loss], out_numpy=True, is_valid=idx < loader.sampler.valid_length)


### PR DESCRIPTION
## Summary
- use clone values for normalization of FFT 

## Testing
- `python -m py_compile models/em_net_model.py trainer.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'einops')*

------
https://chatgpt.com/codex/tasks/task_e_68b15b02ab008329b762757dc8d7b51a